### PR TITLE
Update README to include additional install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,22 @@ https://dl.acm.org/doi/10.1145/3439961.3440002
 ## Requisitos:
 PySimpleGUI
 
+Pillow
+
 ## Instalações:
-sudo apt install python3-pip
 
-sudo apt install python3-tk
+> Nota: 'tkinter' faz parte da biblioteca padrão
 
-pip3 install pysimplegui
+### Instalar pip3 e tkinter (Linux)
+sudo apt install python3-pip python3-tk
 
-### Para executar no Linux:
+### Instalar pip3 (MacOS)
+> Requer [Homebrew](https://brew.sh/)
+
+brew install python3
+
+### Instalar requisitos
+pip3 install pysimplegui pillow
+
+### Para executar:
 python3 main.py


### PR DESCRIPTION
Basically adding the following details:

- The Pillow module (the maintained fork of PIL) is also a requirement for this project. Please note, as per Pillow's docs, "Pillow and PIL cannot co-exist in the same environment".
- Tkinter is part of the Python standard library (since v3.1).
- On MacOS pip3 is automatically installed when python is installed with homebrew